### PR TITLE
Add conditions to transform clinical event type label

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -3,7 +3,7 @@ var clinicalTimelineParser = (function() {
   function transformToTimelineJSON(clinical_timeline_data) {
     var transformToTrack = function(clin_events) {
       var track = {
-        "label":capitalizeFirstLetterLowerCaseRest(clin_events[0].eventType),
+        "label":transformLabel(clin_events[0].eventType),
         visible:true,
         "times":[]
       };
@@ -35,6 +35,21 @@ var clinicalTimelineParser = (function() {
    */
   function capitalizeFirstLetterLowerCaseRest(string) {
       return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
+  }
+  
+  /*
+   * If label is uppercase and less than 5 characters (deemed as abbreviation),
+   * or has both lowercase and uppercase characters,
+   * it is assumed to be intentional and kept intact,
+   * otherwise will be transformed by capitalizeFirstLetterLowerCaseRest
+   */
+  function transformLabel(label) {
+    const mixedCase = /(?=.*[a-z])(?=.*[A-Z])/;
+    const upperCaseOnly = /[A-Z]+[a-z]{0}/;
+    if (mixedCase.test(label) || (upperCaseOnly.test(label) && label.length < 5)) {
+      return label;
+    }
+    return capitalizeFirstLetterLowerCaseRest(label);
   }
 
   return transformToTimelineJSON;

--- a/js/parser.js
+++ b/js/parser.js
@@ -44,8 +44,8 @@ var clinicalTimelineParser = (function() {
    * otherwise will be transformed by capitalizeFirstLetterLowerCaseRest
    */
   function transformLabel(label) {
-    const mixedCase = /(?=.*[a-z])(?=.*[A-Z])/;
-    const upperCaseOnly = /[A-Z]+[a-z]{0}/;
+    var mixedCase = /(?=.*[a-z])(?=.*[A-Z])/;
+    var upperCaseOnly = /[A-Z]+[a-z]{0}/;
     if (mixedCase.test(label) || (upperCaseOnly.test(label) && label.length < 5)) {
       return label;
     }

--- a/test/screenshot_script.sh
+++ b/test/screenshot_script.sh
@@ -2,6 +2,17 @@
 # dir of bash script http://stackoverflow.com/questions/59895
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+
+# From: https://github.com/tremby/imgur.sh/blob/master/imgur.sh
+default_client_id=c9a6efb3d7932fd
+client_id="${IMGUR_CLIENT_ID:=$default_client_id}"
+
+function upload {
+	curl -s -H "Authorization: Client-ID $client_id" -H "Expect: " -F "image=@$1" https://api.imgur.com/3/image.xml | grep -oe 'https://[a-zA-Z0-9./]*'
+	# The "Expect: " header is to get around a problem when using this through
+	# the Squid proxy. Not sure if it's a Squid bug or what.
+}
+
 # patient view screenshot
 screenshot_error_count=0
 for testdata in $(echo ${DIR}/data/data*.json); do
@@ -18,7 +29,7 @@ for testdata in $(echo ${DIR}/data/data*.json); do
         git diff --quiet -- $screenshot_png
         if [[ $? -ne 0 ]]; then
             screenshot_error_count=$(($screenshot_error_count + 1))
-            echo "screenshot differs see:" &&  (curl -F "c=@${screenshot_png}" https://ptpb.pw/ | grep url | cut -d' ' -f2)
+            echo "screenshot differs see:" && upload "${screenshot_png}"
         fi
     done
 done
@@ -34,7 +45,7 @@ phantomjs --ignore-ssl-errors=true ${DIR}/make_screenshots.js \
 git diff --quiet -- $screenshot_png
 if [[ $? -ne 0 ]]; then
     screenshot_error_count=$(($screenshot_error_count + 1))
-    echo "screenshot differs see:" &&  (curl -F "c=@${screenshot_png}" https://ptpb.pw/ | grep url | cut -d' ' -f2)
+    echo "screenshot differs see:" && upload "${screenshot_png}"
 fi
 
 if [[ $screenshot_error_count -gt 0 ]]; then


### PR DESCRIPTION
# What? Why?
Add conditions to transform clinical event type label:
- If event type has mixed cases or is all uppercase with less than 5 characters, it will be kept intact;
- In other cases, event type is transformed by `capitalizeFirstLetterLowerCaseRest`.

# Notify reviewers
@inodb
