### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist/
+.idea/**

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Checks before sending a PR:
 - Run all tests to assure nothing else was accidentally broken. This is done by running: `npm test`.
 - Make sure you have added the necessary tests and [documentation](http://usejsdoc.org/) for your changes.
 
+## Development
+The simplest way to verify your changes is via `index.html`. One iteration may look something like this:
+1. Make code change
+1. Rebuild with `make clean build`
+1. View the change in your browser by loading `index.html`
+You can find json examples to load into the parser
+[here](https://github.com/cBioPortal/clinical-timeline/tree/master/test/data)
+
 clinical-timeline uses [code-climate](https://codeclimate.com/) to maintain code quality and [coveralls](https://coveralls.io) for code-coverage. Please ensure that the [repo GPA](https://codeclimate.com/github/cBioPortal/clinical-timeline) and [code-coverage](https://coveralls.io/github/cBioPortal/clinical-timeline) doesn't falls if not increase post the new commit. Adding new [unit tests](https://github.com/cBioPortal/clinical-timeline/tree/master/test/unit-tests) is most welcomed. 
 
 ## License

--- a/js/clinicalTimeline.js
+++ b/js/clinicalTimeline.js
@@ -886,6 +886,53 @@ var clinicalTimeline = (function(){
   }
 
   /**
+   * Tick values are removed in trimmed areas.
+   * @param  {Number} minDays
+   * @param  {Number} maxDays  
+   * @param  {string} zoomLevel
+   * @return {Number[]} tickValues
+   */
+  timeline.getTickValuesToShow = function (minDays, maxDays, zoomLevel) {
+    var timelineElements = [],
+    tickValuesInt = timeline.getTickValues(minDays, maxDays, zoomLevel).map(function(x) { return Math.round(x);}),
+    ticksToShow = [tickValuesInt[0], tickValuesInt[tickValuesInt.length - 1]];
+
+    d3.selectAll(divId+" .timeline g rect,"+divId+" .timeline g circle").each(function(d, e) {
+      for (
+        var i = parseInt(d.starting_time);
+        i <= parseInt(d.ending_time) + parseInt(clinicalTimelineUtil.getDifferenceTicksDays(zoomLevel));
+        i += clinicalTimelineUtil.getDifferenceTicksDays(zoomLevel)
+      ) {
+         if (timelineElements.indexOf(i) === -1) {
+           timelineElements.push(parseInt(i));
+         }
+       }
+     });
+   
+     timelineElements.sort(function(a, b) { return a - b; });
+   
+     timelineElements.forEach(function(value, index) {
+       if (value > tickValuesInt[0] && value < tickValuesInt[tickValuesInt.length - 1]) {
+         for (var i = 0; i < tickValuesInt.length - 1; i++) {
+           if (value >= tickValuesInt[i] && value <= tickValuesInt[i + 1]) {
+             break;
+           }
+         }
+         if (ticksToShow.indexOf(tickValuesInt[i]) === -1 && i !== tickValuesInt.length - 1) {
+           ticksToShow.push(tickValuesInt[i]);
+         }
+         if (ticksToShow.indexOf(tickValuesInt[i + 1]) === -1 && i !== tickValuesInt.length - 1) {
+           ticksToShow.push(tickValuesInt[i + 1]);
+         }
+       }
+     });
+   
+     ticksToShow.sort(function(a, b) { return a - b; });
+
+     return ticksToShow;
+  }
+
+  /**
    * Change the value of the variable enableTrackToolTips of clinicalTimeline
    * if argument b is provided, else return the existing value
    * @param  {boolean} b

--- a/js/lib/d3-timeline.js
+++ b/js/lib/d3-timeline.js
@@ -448,7 +448,7 @@
         if (!height && !gParentItem.attr("height")) {
           if (itemHeight) {
             // set height based off of item height
-            height = gSize.height + gSize.top - gParentSize.top;
+            height = gSize.height + gSize.top + 3 - gParentSize.top;
             // set bounding rectangle height
             d3.select(gParent[0][0]).attr("height", height);
           } else {


### PR DESCRIPTION
# What? Why?
Fix cBioPortal/cbioportal#6882.

Changes proposed in this pull request:
- Zoom + Trim
  - Issue: when trimming the timeline, zooming would zoom on the
  wrong region
  - Root cause: start and end of zoom region were determined
  according to untrimmed timeline. This was happening inside the
  d3 library itself
  - Fix: take the point the the brush generates, determine its
  placement on the untrimmed timeline, find the nearest tick
  on the trimmed timeline, replace the point with that.
- Cut off circles
  - Issue: mousing over points on the bottom lane of the
  timeline caused them to be cut off when they expanded.
  - Fix: added 3 pixels to the height of the svg

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
![zoom](https://user-images.githubusercontent.com/20069833/71598314-5d20ea80-2b14-11ea-9466-f1145bcbc41e.gif)

