### PR TITLE
Fixes to trimming and spacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist/
+.idea/**

--- a/js/lib/d3-timeline.js
+++ b/js/lib/d3-timeline.js
@@ -448,7 +448,7 @@
         if (!height && !gParentItem.attr("height")) {
           if (itemHeight) {
             // set height based off of item height
-            height = gSize.height + gSize.top - gParentSize.top;
+            height = gSize.height + gSize.top + 3 - gParentSize.top;
             // set bounding rectangle height
             d3.select(gParent[0][0]).attr("height", height);
           } else {


### PR DESCRIPTION
Changes proposed in this pull request:
- Spacing:
  - Issue:
    - Circles on the bottom row were getting cut off when you
  moused over them.
  - Solution:
    - Added 3 pixels of extra space to compensate for this
- Trimming:
  - Issue
    - The trimming logic seemingly lost its mind when you
    zoomed in on a trimmed timeline
  - Fix:
    - There were two issues:
      1) logic for the selection area when you zoom was
      calculating position based on the untrimmed timeline
      2) the selectors to get the timeline elements were
      getting nothing when zoomed
    - I wrote some logic to convert the brush position
    from the untrimmed position to the trimmed position
    - Selectors are now different when the timeline is
    zoomed, looking for a `scrollable` instead of a `timeline`


# Any screenshots or GIFs?
![wew](https://user-images.githubusercontent.com/20069833/72815099-1d8d8000-3c34-11ea-8504-b9ecd7f7c21c.gif)
