### PR TITLE
Clearer ruler annotation + misc

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
 <head>
-  <script src="//code.jquery.com/jquery-latest.min.js"></script>
+  <script src="http://code.jquery.com/jquery-latest.min.js"></script>
   <script src="js/lib/jquery.dataTables.min.js"></script>
   <script src="js/lib/jquery.qtip.min.js"></script>
-  <script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>
+  <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
   <script src="js/lib/underscore-min.js"></script>
   <script>
   /**
@@ -25,11 +25,11 @@
    */
   Object.setPrototypeOf = Object.setPrototypeOf || function(obj, proto) {
     obj.__proto__ = proto;
-    return obj;
+    return obj; 
   }
   </script>
-  <script src="//cdn.rawgit.com/MrRio/jsPDF/v1.3.5/dist/jspdf.min.js"></script>
-  <script src="//html2canvas.hertzen.com/build/html2canvas.js"></script>
+  <script src="http://cdn.rawgit.com/MrRio/jsPDF/v1.3.5/dist/jspdf.min.js"></script>
+  <script src="http://html2canvas.hertzen.com/build/html2canvas.js"></script>
   <script src="js/lib/d3-timeline.js"></script>
   <script src="js/plugins/util.js"></script>
   <script src="js/plugins/pluginPrototype.js"></script>
@@ -43,8 +43,8 @@
   <script src="js/clinicalTimeline.js"></script>
   <script src="js/sanity.js"></script>
   <script src="js/parser.js"></script>
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
-  <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
   <link href="css/lib/jquery.qtip.min.css" type="text/css" rel="stylesheet" />
   <link href="css/lib/dataTables.tableTools.min.css" type="text/css" rel="stylesheet" />
   <style type="text/css">
@@ -173,7 +173,7 @@
       var testData = getURLParameterByName("test");
       var dataFed = "data1";
       var waitForParse = false;
-
+      
       if (jsonURL !== "") {
         if (jsonURL.indexOf("?view=") > -1) {
           jsonURL = jsonURL.substring(0, jsonURL.indexOf("?view="));
@@ -225,42 +225,42 @@
         .enableTrackTooltips(true)
         .plugins([
           {
-            obj: new trimClinicalTimeline("Trim Timeline"),
+            obj: new trimClinicalTimeline("Trim Timeline"), 
             enabled: trimmingForSceenshotTest
-          },
+          },  
           {
-            obj: new clinicalTimelineHelperLines("Helper Lines"),
+            obj: new clinicalTimelineHelperLines("Helper Lines"), 
             enabled: false
-          },
+          }, 
           {
-            obj: new clinicalTimelineZoom("Zoom"),
+            obj: new clinicalTimelineZoom("Zoom"), 
             enabled: !trimmingForSceenshotTest
           },
           {
-            obj: new clinicalTimelineOverviewAxis("Overview Axis"),
+            obj: new clinicalTimelineOverviewAxis("Overview Axis"), 
             enabled:!trimmingForSceenshotTest
           },
           {
-            obj: new clinicalTimelineVerticalLine("Vertical Timeline",
+            obj: new clinicalTimelineVerticalLine("Vertical Timeline", 
               {
-                tooltipControllerId: "#tooltip-controller",
-                hoverBegin: 200,
+                tooltipControllerId: "#tooltip-controller", 
+                hoverBegin: 200, 
                 hoverEnd: 770
               }),
             enabled: false
           },
           {
-            obj: new configCheckManager(null,
+            obj: new configCheckManager(null, 
               {
                 configUlId: "#timeline-wrapper #config-div #config-dropdown"
-              }),
+              }), 
             enabled: true
           },
           {
-            obj: new clinicalTimelineExporter("Export",
+            obj: new clinicalTimelineExporter("Export", 
               {
                 exportDivId : "#export-div",
-              }),
+              }), 
             enabled: true
           }
         ])
@@ -287,7 +287,7 @@
       <span class="caret"></span></button>
       <ul class="dropdown-menu">
         <script type="text/javascript">
-          var exporter = (new clinicalTimelineExporter()).run(null, {exportDivId : "#export-div", timelineDiv : "#timeline"});
+          var exporter = (new clinicalTimelineExporter()).run(null, {exportDivId : "#export-div", timelineDiv : "#timeline"}); 
         </script>
         <li><a href='javascript:exporter.generateSVG()'>SVG Image</a></li>
         <li><a href='javascript:exporter.generatePNG(true)'>PNG Image</a></li>

--- a/js/plugins/overviewAxis.js
+++ b/js/plugins/overviewAxis.js
@@ -21,14 +21,24 @@ clinicalTimelineOverviewAxis.prototype.run = function(timeline, spec) {
     zoomFactor = timeline.zoomFactor(),
     divId = timeline.divId(),
     overviewSVG = d3.select(divId+" .overview"),
-    originalZoomLevel = timeline.computeZoomLevel(readOnlyVars.minDays, readOnlyVars.maxDays, timeline.width()),
+    originalZoomLevel = timeline.computeZoomLevel(
+      readOnlyVars.minDays,
+      readOnlyVars.maxDays,
+      timeline.width(),
+      timeline.fractionTimelineShown()
+    ),
     overviewAxisTicks = timeline.getTickValues(readOnlyVars.minDays, readOnlyVars.maxDays, originalZoomLevel),
     minDayTick = overviewAxisTicks[0],
     maxDayTick =  overviewAxisTicks[overviewAxisTicks.length-1],
     overViewScale = d3.time.scale()
       .domain([clinicalTimelineUtil.roundDown(readOnlyVars.minDays, clinicalTimelineUtil.getDifferenceTicksDays(originalZoomLevel)), clinicalTimelineUtil.roundUp(readOnlyVars.maxDays, clinicalTimelineUtil.getDifferenceTicksDays(originalZoomLevel))])
       .range([0 + margin.overviewAxis.left, overviewAxisWidth - margin.overviewAxis.right]),
-    zoomLevel = timeline.computeZoomLevel(readOnlyVars.minDays, readOnlyVars.maxDays, timeline.width() * zoomFactor),
+    zoomLevel = timeline.computeZoomLevel(
+      readOnlyVars.minDays,
+      readOnlyVars.maxDays,
+      timeline.width() * zoomFactor,
+      timeline.fractionTimelineShown()
+    ),
     startAllowedOverview = overViewScale(clinicalTimelineUtil.roundDown(readOnlyVars.minDays, clinicalTimelineUtil.getDifferenceTicksDays(zoomLevel))) - overViewScale(clinicalTimelineUtil.roundDown(readOnlyVars.minDays, clinicalTimelineUtil.getDifferenceTicksDays(originalZoomLevel))),
     endAllowedOverview = overViewScale(clinicalTimelineUtil.roundUp(readOnlyVars.maxDays, clinicalTimelineUtil.getDifferenceTicksDays(originalZoomLevel))) - overViewScale(clinicalTimelineUtil.roundUp(readOnlyVars.maxDays, clinicalTimelineUtil.getDifferenceTicksDays(zoomLevel)));
 

--- a/test/unit-tests/basic-test.js
+++ b/test/unit-tests/basic-test.js
@@ -61,12 +61,12 @@ describe('clinicalTimeline.formatTime', function() {
      expect("10d").to.equal(formatTime(daysToTimeObject(10), "days"));
      expect("10d").to.equal(formatTime(daysToTimeObject(10), "3days"));
      expect("10d").to.equal(formatTime(daysToTimeObject(10), "10days"));
-     expect("610d").to.equal(formatTime(daysToTimeObject(610), "days"));
-     expect("610d").to.equal(formatTime(daysToTimeObject(610), "3days"));
-     expect("610d").to.equal(formatTime(daysToTimeObject(610), "10days"));
+     expect("1y8m5d").to.equal(formatTime(daysToTimeObject(610), "days"));
+     expect("1y8m5d").to.equal(formatTime(daysToTimeObject(610), "3days"));
+     expect("1y8m5d").to.equal(formatTime(daysToTimeObject(610), "10days"));
 
      expect("0m").to.equal(formatTime(daysToTimeObject(10), "months"));
-     expect("20m").to.equal(formatTime(daysToTimeObject(610), "months"));
+     expect("1y8m").to.equal(formatTime(daysToTimeObject(610), "months"));
 
      expect("0y").to.equal(formatTime(daysToTimeObject(10), "years"));
      expect("1y").to.equal(formatTime(daysToTimeObject(610), "years"));


### PR DESCRIPTION
Changes proposed in this pull request:
- Ruler annotation
  - Problem
    - Month and day annotations for large values were hard to
    understand at a glance
  - Solution
    - Write larger values in `y{}m{}d{}` form
    - Ex: "1860d" => "5y1m5d"
- Zooming still terrible
  - Problem
    - The start of the zoom is fixed now, but the region ends
    too soon
  - Fix
    - Adjusted the zoom region when trimmed
- Scroll/drag text renders twice
- "Click + drag to zoom" text not part of right element,
flickers

@inodb
