### PR TITLE
Fix for single click zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,34 @@ clinical-timeline uses [code-climate](https://codeclimate.com/) to maintain code
 
 ## License
 [LGPL](https://github.com/cBioPortal/clinical-timeline/blob/master/LICENSE)
+
+## Testing
+### Setup:
+1. Run `make clean build`
+2. Copy the repo into frontend/node_modules
+3. Start up the frontend
+
+### Testing in timeline repo
+- Make sure `timeline-example.json` looks right
+- Make sure you can zoom, trim
+
+### Testing in actual frontend
+Link: http://localhost:3000/patient?studyId=lgg_ucsf_2014&caseId=P17
+- Single click zoom
+  - Should zoom in ~ 50%
+  - Should not break if you click before the first tick mark
+  - Should not break if you click after the last tick mark
+  - Should not break if select a trim
+- Click and drag zoom
+  - Should show ~ full region you selected
+  - Should not break if you click before the first tick mark
+  - Should not break if you click after the last tick mark 
+  - Should have reasonable units
+  - Should not break if you select a region that includes a trim
+  - Should zoom in more if you select a smaller region
+- General zooming
+  - Points and ticks are in the right place (verify by looking at start date)
+  - Should not break if you zoom in, zoom out, zoom in
+- Zooming + trimming
+  - http://localhost:3000/patient?studyId=lgg_ucsf_2014&caseId=P04
+  - If no trimming occurs when zoomed out, no trimming should occur if you zoom in

--- a/js/plugins/zoom.js
+++ b/js/plugins/zoom.js
@@ -94,7 +94,12 @@ clinicalTimelineZoom.prototype.run = function(timeline, spec) {
       timeline.trimmed(false); // this will get switched back to true by timTimeline
       var extendLeft = parseInt(d3.select(timeline.divId()+" .extent").attr("x"));
       var extendRight = extendLeft + parseInt(d3.select(timeline.divId()+" .extent").attr("width"));
+      
+      // if the zoom region is tiny, the user clicked instead of clicking 
+      // and dragging. In this case, just make the zoom region half of the timeline,
+      // centered around where they clicked
       if (extendRight < extendLeft + 2) {
+        var zoomFactor = 2.0;
         extendLeft = Math.max(0, extendLeft - width / 4);
         extendRight = Math.min(width, extendRight + width / 4);
       }
@@ -122,7 +127,9 @@ clinicalTimelineZoom.prototype.run = function(timeline, spec) {
       // Seriously, this seems to work, and I'm at my wit's end.
       // So for now, just multiply the value that totally makes sense and should work
       // by 0.75, because that works better.
-      timeline.zoomFactor(0.75 * width / selectWidth);
+      // Also, if the zoomFactor was predetermined as a result of the user clicking
+      // rather than clicking and dragging, use that value
+      timeline.zoomFactor(zoomFactor ? zoomFactor : 0.75 * width / selectWidth);
       if (timeline.zoomFactor() > 0) {
         timeline.zoomFactor(Math.min(timeline.zoomFactor(), timeline.computeZoomFactor("days", minDays, maxDays, width)));
       } else {


### PR DESCRIPTION
Changes proposed in this pull request:
Single click zoom was not working because the calculations
for zoom factor were not respecting the new zoom region
established by the single click zoom logic

# Notify reviewers
@inodb
