### PR TITLE
Zoom Style Fixes

### DIFF
--- a/js/clinicalTimeline.js
+++ b/js/clinicalTimeline.js
@@ -171,15 +171,18 @@ var clinicalTimeline = (function(){
           addTrackTooltip($(this), allData);
         }
       });
-      // Add track button
-      svg.attr("height", parseInt(svg.attr("height")) + 15);
-      svg.insert("text")
-        .attr("transform", "translate(0,"+svg.attr("height")+")")
-        .attr("class", "timeline-label")
-        .text("Add track")
-        .attr("id", "addtrack");
-      addNewTrackTooltip($("#addtrack"));
     }
+
+    // Add track button. Hide, but still add if no track tooltips to stop text collisions.
+    svg.attr("height", parseInt(svg.attr("height")) + 15);
+    svg.insert("text")
+      .attr("transform", "translate(0,"+svg.attr("height")+")")
+      .attr("class", "timeline-label")
+      .style("visibility", enableTrackTooltips ? "" : "hidden")
+      .text("Add track")
+      .attr("id", "addtrack");
+    addNewTrackTooltip($("#addtrack"));
+    
     svg.insert("text")
       .attr("transform", "translate(0, 15)")
       .attr("class", "timeline-label")

--- a/js/plugins/trimTimeline.js
+++ b/js/plugins/trimTimeline.js
@@ -246,11 +246,22 @@ trimClinicalTimeline.prototype.run = function (timeline, spec) {
       var chart = timeline.getReadOnlyVars().chart;
       var _svg = d3.select(divId + " svg");
       // i zoomed
+      d3.select(divId + " svg")
+          .insert("rect")
+          .attr("transform", "translate("+(parseInt(_svg.attr("width"))-72)+", "+parseInt(_svg.attr("height")-16)+")")
+          .attr("width", 68)
+          .attr("height", 14)
+          .attr("ry", 2)
+          .attr("rx", 2)
+          .style("stroke-width", 1)
+          .style("fill", "lightgray")
+          .style("stroke", "gray");
+      
       var zoomBtn = d3.select(divId + " svg")
           .insert("text")
           .attr("transform", "translate("+(parseInt(_svg.attr("width"))-70)+", "+parseInt(_svg.attr("height")-5)+")")
           .attr("class", "timeline-label")
-          .text("Zoom out")
+          .text("Reset zoom")
           .style("cursor", "zoom-out")
           .attr("id", "timelineZoomOut");
       zoomBtn.on("click", function() {

--- a/js/plugins/zoom.js
+++ b/js/plugins/zoom.js
@@ -149,11 +149,21 @@ clinicalTimelineZoom.prototype.run = function(timeline, spec) {
       d3.select(divId).style("visibility", "hidden");
       timeline();
       d3.select(divId).style("visibility", "visible");
+      d3.select(divId + " svg")
+        .insert("rect")
+        .attr("transform", "translate("+(parseInt(svg.attr("width"))-72)+", "+parseInt(svg.attr("height")-16)+")")
+        .attr("width", 68)
+        .attr("height", 14)
+        .attr("ry", 2)
+        .attr("rx", 2)
+        .style("stroke-width", 1)
+        .style("fill", "lightgray")
+        .style("stroke", "gray");
       var zoomBtn = d3.select(divId + " svg")
         .insert("text")
         .attr("transform", "translate("+(parseInt(svg.attr("width"))-70)+", "+parseInt(svg.attr("height")-5)+")")
         .attr("class", "timeline-label")
-        .text("Zoom out")
+        .text("Reset zoom")
         .style("cursor", "zoom-out")
         .attr("id", "timelineZoomOut");
       zoomBtn.on("click", function() {
@@ -184,8 +194,8 @@ clinicalTimelineZoom.prototype.run = function(timeline, spec) {
       overlayBrush.attr("class", "brush")
         .call(brush)
         .selectAll(divId+' .extent,'+divId+' .background,'+divId+' .resize rect')
-          .attr("height", gBoundingBox.height)
-          .attr("y", 20)
+          .attr("height", gBoundingBox.height + 20)
+          .attr("y", 0)
           .style("cursor", "zoom-in");
       zoomExplanation(divId, svg, "Click + drag to zoom", "hidden", 120);
       d3.select(divId+' .background').on("mouseover", function() {
@@ -211,7 +221,7 @@ clinicalTimelineZoom.prototype.run = function(timeline, spec) {
    * @param  {number} pos        position of the explanation's text
    */
   function zoomExplanation(divId, svg, text, visibility, pos) {
-    d3.select(divId + " svg g .brush")
+    d3.select(divId + " svg")
       .insert("text")
       .attr("transform", "translate("+(parseInt(svg.attr("width"))-pos)+", "+parseInt(svg.attr("height")-5)+")")
       .attr("class", "timeline-label")


### PR DESCRIPTION
Changes proposed in this pull request:
- Changed the selector for the pan message so it shows up
- Changed "Zoom out" to "Reset zoom"
- Added rectangle around zoom out text to make it look like a
  button.
- Allow zooming on the ruler
- Forced some whitespace so that data tracks don't overlap
  with text.

@inodb
